### PR TITLE
Add cross-platform adb/aapt path detection

### DIFF
--- a/libs/core/__init__.py
+++ b/libs/core/__init__.py
@@ -91,10 +91,15 @@ class Bootstrapper(object):
 
         backsmali_path = os.path.join(tools_dir, "baksmali.jar")
         apktool_path = os.path.join(tools_dir, "apktool.jar")
-        adb_path = os.path.join(tools_dir + '\\unpacker', "adb.exe")
-        frida32_path = os.path.join(tools_dir + '\\unpacker', "hexl-server-arm32")
-        frida64_path = os.path.join(tools_dir + '\\unpacker', "hexl-server-arm64")
-        aapt_apth = os.path.join(tools_dir + '\\unpacker', "aapt.exe")
+        unpacker_dir = os.path.join(tools_dir, "unpacker")
+        if platform.system() == "Windows":
+            adb_path = os.path.join(unpacker_dir, "adb.exe")
+            aapt_apth = os.path.join(unpacker_dir, "aapt.exe")
+        else:
+            adb_path = shutil.which("adb") or os.path.join(unpacker_dir, "adb")
+            aapt_apth = shutil.which("aapt") or os.path.join(unpacker_dir, "aapt")
+        frida32_path = os.path.join(unpacker_dir, "hexl-server-arm32")
+        frida64_path = os.path.join(unpacker_dir, "hexl-server-arm64")
         download_path = os.path.join(out_dir, "download")
         txt_result_path = os.path.join(out_dir, "result_" + str(create_time) + ".txt")
         xls_result_path = os.path.join(out_dir, "result_" + str(create_time) + ".xlsx")


### PR DESCRIPTION
## Summary
- support macOS/Linux by detecting platform and using `shutil.which` for adb/aapt
- keep Frida server paths relative to `tools/unpacker`

## Testing
- `python -m py_compile libs/core/__init__.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891997b9f948324b1844126bf1fa30d