### PR TITLE
Add cross-platform adb/aapt path detection

### DIFF
--- a/libs/core/__init__.py
+++ b/libs/core/__init__.py
@@ -24,7 +24,7 @@ frida32_path = ""
 frida64_path = ""
 
 # aapt 所在路径
-aapt_apth = ""
+aapt_path = ""
 
 # 系统类型
 os_type = ""
@@ -48,7 +48,7 @@ class Bootstrapper(object):
         global adb_path
         global frida32_path
         global frida64_path
-        global aapt_apth
+        global aapt_path
         global os_type
         global output_path
         global script_root_dir
@@ -91,10 +91,25 @@ class Bootstrapper(object):
 
         backsmali_path = os.path.join(tools_dir, "baksmali.jar")
         apktool_path = os.path.join(tools_dir, "apktool.jar")
-        adb_path = os.path.join(tools_dir + '\\unpacker', "adb.exe")
-        frida32_path = os.path.join(tools_dir + '\\unpacker', "hexl-server-arm32")
-        frida64_path = os.path.join(tools_dir + '\\unpacker', "hexl-server-arm64")
-        aapt_apth = os.path.join(tools_dir + '\\unpacker', "aapt.exe")
+        unpacker_dir = os.path.join(tools_dir, "unpacker")
+        if platform.system() == "Windows":
+            adb_path = os.path.join(unpacker_dir, "adb.exe")
+            aapt_path = os.path.join(unpacker_dir, "aapt.exe")
+        else:
+            adb_path = shutil.which("adb") or os.path.join(unpacker_dir, "adb")
+            aapt_path = shutil.which("aapt") or os.path.join(unpacker_dir, "aapt")
+        for tool_name, tool in (("adb", adb_path), ("aapt", aapt_path)):
+            resolved = shutil.which(tool_name) or tool
+            if not os.path.exists(resolved) or not os.access(resolved, os.X_OK):
+                raise FileNotFoundError(
+                    "%s not found or not executable. Please ensure it is installed or placed in tools/unpacker" % tool_name
+                )
+            if tool_name == "adb":
+                adb_path = resolved
+            else:
+                aapt_path = resolved
+        frida32_path = os.path.join(unpacker_dir, "hexl-server-arm32")
+        frida64_path = os.path.join(unpacker_dir, "hexl-server-arm64")
         download_path = os.path.join(out_dir, "download")
         txt_result_path = os.path.join(out_dir, "result_" + str(create_time) + ".txt")
         xls_result_path = os.path.join(out_dir, "result_" + str(create_time) + ".xlsx")

--- a/libs/core/__init__.py
+++ b/libs/core/__init__.py
@@ -99,15 +99,10 @@ class Bootstrapper(object):
             adb_path = shutil.which("adb") or os.path.join(unpacker_dir, "adb")
             aapt_path = shutil.which("aapt") or os.path.join(unpacker_dir, "aapt")
         for tool_name, tool in (("adb", adb_path), ("aapt", aapt_path)):
-            resolved = shutil.which(tool_name) or tool
-            if not os.path.exists(resolved) or not os.access(resolved, os.X_OK):
+            if not os.path.exists(tool) or not os.access(tool, os.X_OK):
                 raise FileNotFoundError(
                     "%s not found or not executable. Please ensure it is installed or placed in tools/unpacker" % tool_name
                 )
-            if tool_name == "adb":
-                adb_path = resolved
-            else:
-                aapt_path = resolved
         frida32_path = os.path.join(unpacker_dir, "hexl-server-arm32")
         frida64_path = os.path.join(unpacker_dir, "hexl-server-arm64")
         download_path = os.path.join(out_dir, "download")


### PR DESCRIPTION
## Summary
- support macOS/Linux by detecting platform and using `shutil.which` for adb/aapt
- guard against missing adb/aapt binaries in initializer
- start Frida server with a single `su` command to avoid hanging and extract app info via `aapt`
- validate resolved adb/aapt executables and surface clear errors when they are missing or not executable
- ensure Android unpack flow checks for aapt path and executability before invoking it
- detect `su` availability before running privileged commands, falling back to non-`su` execution when absent
- retry Frida setup commands without `su` when privileged execution fails, logging return codes for easier troubleshooting

## Testing
- `python -m py_compile libs/core/__init__.py libs/task/android_task.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891997b9f948324b1844126bf1fa30d